### PR TITLE
update incorrect wokwi link

### DIFF
--- a/src/pages/guides/hardware-grant.tsx
+++ b/src/pages/guides/hardware-grant.tsx
@@ -123,7 +123,7 @@ Created On: "10/7/2025"
             <p className="mb-3">
               Look at the available parts below and start your project. A typical project will have a 3d model and if it is possible to, make a{" "}
               <a
-                href="https://hackclub.com/slack/?event=grounded"
+                href="https://wokwi.com/"
                 target="_blank"
                 rel="noreferrer"
                 className="text-emerald-400 underline"


### PR DESCRIPTION
<img width="917" height="138" alt="image" src="https://github.com/user-attachments/assets/ed88917b-4d44-48ec-b71d-df6ff360f9e0" />
this was redirecting to https://hackclub.com/slack/?event=grounded, now to https://wokwi.com/